### PR TITLE
fix: resolve UnicodeEncodeError on Windows Turkish/non-UTF-8 locales and prevent settings reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This version addresses the most critical bug preventing users from configuring t
 ### 📦 Install from Flow Launcher Plugin Store
 
 1. Launch Flow Launcher (`Alt + Space`)
-2. Type `pm install CurrencyPP by SweedXD` and hit **Enter**
+2. Type `pm install CurrencyPP by SweedXD` and search for CurrencyPP (UI Fixed) and hit **Enter**
 
 That’s it — the plugin will be installed and ready to use instantly 🎉
 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,64 @@
 import sys
 import os
+
+# Reconfigure standard streams to use UTF-8 (prevents encoding crashes under Windows Turkish/non-UTF-8 locales)
+for stream in (sys.stdout, sys.stderr):
+    if stream and hasattr(stream, 'reconfigure'):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except Exception:
+            pass
+
 parent_folder_path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(parent_folder_path)
 sys.path.append(os.path.join(parent_folder_path, 'lib'))
 sys.path.append(os.path.join(parent_folder_path, 'src'))
 
-from currencypp import CurrencyPP
+# Monkeypatch Flox components to resolve encoding issues and reload bugs without touching the library files
+try:
+    from flox.settings import Settings
+    import json
+
+    def patched_load(self):
+        data = {}
+        with open(self._filepath, 'r', encoding='utf-8') as f:
+            try:
+                data.update(json.load(f))
+            except json.decoder.JSONDecodeError:
+                pass
+        self._save = False
+        self.clear()
+        self.update(data)
+        self._save = True
+
+    def patched_save(self):
+        if self._save:
+            data = {}
+            data.update(self)
+            with open(self._filepath, 'w', encoding='utf-8') as f:
+                json.dump(data, f, sort_keys=True, indent=4)
+
+    Settings._load = patched_load
+    Settings.save = patched_save
+    Settings.reload = lambda self: self._load()
+except Exception:
+    pass
+
+try:
+    import flox.utils
+    from pathlib import Path
+    
+    def patched_write_json(data, path):
+        if not Path(path).parent.exists():
+            Path(path).parent.mkdir(parents=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f)
+            
+    flox.utils.write_json = patched_write_json
+except Exception:
+    pass
+
+from currencypp import CurrencyPP  # type: ignore
 
 if __name__ == "__main__":
     CurrencyPP()

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "CurrencyPP",
     "Description": "A Better Currency Converter",
     "Author": "SweedXD",
-    "Version": "4.0.1",
+    "Version": "4.0.2",
     "Language": "python",
     "Website": "https://github.com/SweedXD/CurrencyPP",
     "IcoPath": "src/CurrencyPP.png",

--- a/src/currencypp.py
+++ b/src/currencypp.py
@@ -3,11 +3,107 @@ from flox.utils import cache_path
 from parsy import ParseError
 from currencyparser import make_parser, ParserProperties
 from flox import Flox, clipboard
+from functools import cached_property
 
 
 class CurrencyPP(Flox):
 
     broker = None
+
+    @cached_property
+    def manifest(self):
+        import os
+        import json
+        with open(os.path.join(self.plugindir, 'plugin.json'), 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    @property
+    def app_settings(self):
+        import os
+        import json
+        with open(os.path.join(self.appdata, 'Settings', 'Settings.json'), 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    @cached_property
+    def logger(self):
+        import logging
+        import logging.handlers
+        logger = logging.getLogger('')
+        formatter = logging.Formatter(
+            '%(asctime)s %(levelname)s (%(filename)s): %(message)s',
+            datefmt='%H:%M:%S')
+        logfile = logging.handlers.RotatingFileHandler(
+                self.logfile,
+                maxBytes=1024 * 2024,
+                backupCount=1,
+                encoding='utf-8')
+        logfile.setFormatter(formatter)
+        if not logger.handlers:
+            logger.addHandler(logfile)
+        logger.setLevel(logging.WARNING)
+        return logger
+
+    def run(self, debug=None):
+        import json
+        import sys
+        import time
+        if debug:
+            self._debug = debug
+        self.rpc_request = {'method': 'query', 'parameters': ['']}
+        if len(sys.argv) > 1:
+            try:
+                self.rpc_request = json.loads(sys.argv[1])
+            except Exception as e:
+                self.logger.error(f"Failed to parse RPC request: {e}")
+        
+        # Sync settings from RPC request
+        if 'settings' in self.rpc_request.keys():
+            self._settings = self.rpc_request['settings']
+            self.logger.debug('Loaded settings from RPC request')
+            if hasattr(self, 'settings') and self._settings:
+                try:
+                    old_save = self.settings._save
+                    self.settings._save = False
+                    self.settings.update(self._settings)
+                    self.settings._save = old_save
+                except Exception as e:
+                    self.logger.error(f"Failed to update self.settings with RPC settings: {e}")
+            # Rerun _read_config to apply updated settings before query
+            try:
+                self._read_config()
+            except Exception as e:
+                self.logger.error(f"Failed to run _read_config: {e}")
+                
+        if not self._debug:
+            self._debug = self.settings.get('debug', False)
+        if self._debug:
+            self.logger_level("debug")
+            
+        self.logger.debug(f'Request:\n{json.dumps(self.rpc_request, indent=4)}')
+        self.logger.debug(f"Params: {self.rpc_request.get('parameters')}")
+        
+        request_method_name = self.rpc_request.get("method")
+        if request_method_name == 'query' or request_method_name == 'context_menu':
+            request_method_name = f"_{request_method_name}"
+
+        request_parameters = self.rpc_request.get("parameters")
+        request_method = getattr(self, request_method_name)
+        try:
+            results = request_method(*request_parameters) or self._results
+        except Exception as e:
+            self.logger.exception(e)
+            results = self.exception(e) or self._results
+            
+        line_break = '#' * 10
+        ms = int((time.time() - self._start) * 1000)
+        self.logger.debug(f'{line_break} Total time: {ms}ms {line_break}')
+        
+        if request_method_name == "_query" or request_method_name == "_context_menu":
+            results = {"result": results}
+            if self.settings != self._settings and self._settings is not None:
+                results['SettingsChange'] = self.settings
+
+            print(json.dumps(results))
 
     def __init__(self):
         """Initialize the CurrencyPP plugin."""

--- a/src/exchange.py
+++ b/src/exchange.py
@@ -111,7 +111,7 @@ class ExchangeRates():
         return False
 
     def load_from_file(self):
-        with open(self._file_path) as f:
+        with open(self._file_path, encoding='utf-8') as f:
             data = json.load(f)
 
         self.last_update = datetime.strptime(
@@ -128,7 +128,7 @@ class ExchangeRates():
             'last_update': self.last_update.strftime('%Y-%m-%dT%H:%M:%S')
         }
 
-        with open(self._file_path, 'w') as f:
+        with open(self._file_path, 'w', encoding='utf-8') as f:
             json.dump(data, f)
 
     def rate(self, code):


### PR DESCRIPTION
### Summary
This PR addresses two critical bugs that affect plugin usability, particularly for users on non-UTF-8 system locales (e.g., Windows Turkish locale / CP1254).

### Changes Made
1. **Unicode/Encoding Crash Fixes:**
   - Reconfigured standard output and error streams (`sys.stdout` & `sys.stderr`) to use `utf-8` on startup in `main.py`.
   - Enforced `utf-8` encoding when reading/writing settings and rates files inside `exchange.py`.
   - Monkeypatched `flox.settings.Settings` file I/O and `flox.utils.write_json` to guarantee `utf-8` encoding. This prevents `UnicodeEncodeError` when handling unicode currency characters like the Turkish Lira sign (`₺` / `\u20ba`).

2. **Settings Synchronization & Reset Fix:**
   - Overrode the `run()` method in the `CurrencyPP` subclass to safely sync incoming RPC request settings with plugin configuration at runtime and reload it properly before queries execute.
   - Fixed the case-sensitivity bug in Flox's `launcher.py` (which compared `self._settings` to non-existent capitalized `Settings`) by patching the comparison to check `self.settings != self._settings`. This stops Flow Launcher from immediately overriding and resetting user settings back to defaults.
   - Patched `Settings._load` to clear the configuration dictionary before reloading, ensuring that deleted settings keys are correctly cleaned up.

Closes #2
